### PR TITLE
Bug that the containerSize is not known yet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ This option is not always ideal, and in some older browsers, may not work as exp
     // which allows the scope to compile first. It also requires the 'mbScrollbar' Service to be injected
     mbScrollbar.recalculate();
 
+## Scrolling
+To scroll to a fixed point a method was added to the `mbScrollbar` service. Easily call `mbScrollbar.scrollTo(0)` to change the scroll position.
+	
 ## Configuration
 
 You should pass an object as the value of `mb-scrollbar`. Here is an example with all of the attributes you may set. Shown values are the default values.

--- a/mb-scrollbar.js
+++ b/mb-scrollbar.js
@@ -40,7 +40,8 @@ angular.module('mb-scrollbar', [])
                     width: 6,
                     hoverWidth: 8,
                     color: 'rgba(0,0,0,.6)',
-                    show: false
+                    show: false,
+					margin : 0
                 },
                 scrollbarContainer: {
                     width: 12,
@@ -66,7 +67,7 @@ angular.module('mb-scrollbar', [])
             var child = angular.element( element[0].querySelector('.ngscroll-container') ),
                 scrollbarContainer = angular.element( element[0].querySelector('.ngscroll-scrollbar-container') ),
                 scrollbar = angular.element( scrollbarContainer.children()[0] ),
-                containerSize = ifVertElseHor( element[0].offsetHeight, element[0].offsetWidth),
+                containerSize = 0,
                 scrollbarLength,
                 length = 0;
 
@@ -116,6 +117,7 @@ angular.module('mb-scrollbar', [])
 
             // On item set change
             var recalculate = function() {
+				
                 ifVertElseHor(function() {
                     child.css('height', 'auto');
                     length = child[0].scrollHeight || 0;
@@ -130,6 +132,9 @@ angular.module('mb-scrollbar', [])
 
                 })();
 
+				// Bug that the containerSize is not known at the initialisation of the script. After a recalculate it is known, update and use it.
+				containerSize = ifVertElseHor( element[0].offsetHeight, element[0].offsetWidth);
+				
                 // A higher drag-speed modifier on longer container sizes makes for more comfortable scrolling
                 config.dragSpeedModifier = Math.max(1, 1 / ( scrollbarLength / containerSize ));
 

--- a/mb-scrollbar.js
+++ b/mb-scrollbar.js
@@ -171,6 +171,12 @@ angular.module('mb-scrollbar', [])
                     recalculate();
                 }, 5);
             });
+            
+            scope.$on('scrollToMBScrollbars', function (v, offset, b) {
+            	setTimeout(function () {
+            		scrollTo(offset);
+            	}, 5);
+            });
 
             // Move on scroll
             child.on('mousewheel', function(event) {
@@ -265,5 +271,10 @@ angular.module('mb-scrollbar', [])
         setTimeout(function() {
             $scope.$broadcast('recalculateMBScrollbars');
         }, 5);
-    }
+    };
+    this.scrollTo = function ($scope, v) {
+    	 setTimeout(function() {
+             $scope.$broadcast('scrollToMBScrollbars', v);
+         }, 5);
+    };
 });


### PR DESCRIPTION
In my case the mb-scrollbar directive is inited before the size is known. Because the height is calculated afterwards with another directive. At the start the `containerSize` is `0`. And the `containerSize` is not updated in the `recalculate()` In this fix `containerSize` is updated after every `recalculate()`.

Also added a `scrollTo` method that can be called on the `mbService`.
